### PR TITLE
Apple Silicon Support

### DIFF
--- a/include/fficonfig.h.in
+++ b/include/fficonfig.h.in
@@ -18,7 +18,7 @@
 #cmakedefine FFI_DEBUG
 
 /* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
-#cmakedefine FFI_EXEC_TRAMPOLINE_TABLE
+#cmakedefine01 FFI_EXEC_TRAMPOLINE_TABLE
 
 /* Define this if you want to enable pax emulated trampolines */
 #cmakedefine FFI_MMAP_EXEC_EMUTRAMP_PAX


### PR DESCRIPTION
In order for libffi to compile on Apple Silicon this trampoline table macro has to have the value 0 or 1.